### PR TITLE
Update image versions and make some small improvements to Dockerfile/docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,24 @@
 version: '3'
- 
+
 services:
   sneezy-db:
-    image: sneezymud/sneezy-db:55
+    image: sneezymud/sneezy-db:57
     container_name: sneezy-db
     volumes:
       - sneezydb:/var/lib/mysql
     restart: always
 
   sneezy:
+    # Doing this here instead of in the Dockerfile ensures that the files inside the Docker volume have correct ownership. Those files aren't accessible to the Dockerfile, as they won't be mounted until the container is created. This is helpful in case a new file ever needs to be copied into the volume.
+    command: /bin/bash -c "chown -R sneezy:sneezy /home/sneezy && su sneezy -c './sneezy'"
     depends_on:
       - sneezy-db
-    image: sneezymud/sneezymud:58
+    image: sneezymud/sneezymud:latest
     container_name: sneezy
     cap_add:
       - SYS_PTRACE
     ports:
-        - "7900:7900"
+      - "7900:7900"
     restart: always
     volumes:
       - sneezy-lib:/home/sneezy/lib/
@@ -25,18 +27,18 @@ services:
     container_name: sneezy-buildertools
     image: sneezymud/sneezymud-buildertools:59
     ports:
-        - "5001:5000"
+      - "5001:5000"
     depends_on:
-        - sneezy-db
+      - sneezy-db
     restart: always
 
   webclient:
     container_name: sneezy-webclient
-    image: sneezymud/webclient:55
+    image: sneezymud/webclient:60
     ports:
-        - "8080:80"
+      - "8080:80"
     depends_on:
-        - sneezy-db
+      - sneezy-db
     restart: always
 
   websockify:
@@ -48,7 +50,7 @@ services:
     ports:
       - "7901:7901"
     depends_on:
-        - sneezy-db
+      - sneezy-db
     restart: always
 
 volumes:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,29 +1,43 @@
-FROM ubuntu:focal as build
+FROM ubuntu:focal AS build
 LABEL maintainer Elmo Todurov <elmo.todurov@eesti.ee>
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=utc apt-get install --yes --no-install-recommends build-essential libboost-dev libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libmariadbclient-dev scons libcurl4-openssl-dev git ca-certificates
+# Set this first to ensure it applies to all commands
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Removing cache after install reduces image size
+RUN apt-get update && TZ=utc apt-get install --yes --no-install-recommends build-essential libboost-dev libboost-program-options-dev libboost-regex-dev libboost-filesystem-dev libboost-system-dev libmariadbclient-dev scons libcurl4-openssl-dev git ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ARG UID=1000
 ARG BRANCH="master"
-RUN useradd -m -u $UID sneezy
-USER sneezy
 
-WORKDIR /home/sneezy
+# This could possibly also be accomplished by passing the --no-cache flag
 ARG FORCE_REBUILD=1
-RUN echo Building from branch: $BRANCH; git clone --depth 1 --shallow-submodules --recurse-submodules --single-branch --branch $BRANCH --no-tags https://github.com/sneezymud/sneezymud
-WORKDIR /home/sneezy/sneezymud/code
-RUN scons -j`nproc` -Q debug=1 sanitize=1 fortify=1 olevel=2 check sneezy
 
-FROM ubuntu:focal as run
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=utc apt-get install --yes --no-install-recommends libboost-program-options1.71.0 libboost-regex1.71.0 libboost-filesystem1.71.0 libboost-system1.71.0 libmariadb3 libcurl4 libasan5 gdb
+# Combining commands reduces the number of layers, which reduces image size
+RUN useradd -m -u "$UID" sneezy && \
+  echo Building from branch: "$BRANCH" && \
+  git clone --depth 1 --shallow-submodules --recurse-submodules --single-branch --branch "$BRANCH" --no-tags https://github.com/sneezymud/sneezymud /home/sneezy/sneezymud && \
+  scons -C /home/sneezy/sneezymud/code -j`nproc` -Q debug=1 sanitize=1 fortify=1 olevel=2 sneezy
+
+FROM ubuntu:focal AS run
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && TZ=utc apt-get install --yes --no-install-recommends libboost-program-options1.71.0 libboost-regex1.71.0 libboost-filesystem1.71.0 libboost-system1.71.0 libmariadb3 libcurl4 libasan5 gdb && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ARG UID=1000
-RUN useradd -m -u $UID sneezy
-RUN mkdir -p /home/sneezy/code/objs/
-RUN mkdir -p /home/sneezy/lib
-WORKDIR /home/sneezy/code
+
+RUN useradd -m -u "$UID" sneezy && \
+  mkdir -p /home/sneezy/code/objs/ && \
+  mkdir -p /home/sneezy/lib
+
 COPY --from=build /home/sneezy/sneezymud/code/sneezy /home/sneezy/code/sneezy
 COPY --from=build /home/sneezy/sneezymud/lib /home/sneezy/lib
-COPY --from=build /home/sneezy/sneezymud/code/sneezy.cfg /home/sneezy/code/sneezy.cfg 
+COPY --from=build /home/sneezy/sneezymud/code/sneezy.cfg /home/sneezy/code/sneezy.cfg
 RUN chown -R sneezy:sneezy /home/sneezy
-USER sneezy
 EXPOSE 7900
-CMD ./sneezy
+
+# This is necessary because the lib folder is searched for relative to the working directory
+WORKDIR /home/sneezy/code
+
+# Don't run the binary here - do it from the docker-compose file to allow changing ownership of volume files before switching to sneezy user and starting game.


### PR DESCRIPTION
First of all, this just updates the container images to use the newest versions available. The sneezy container uses the 'latest' tag, as that will always be up to date due to the GitHub action that publishes the new builds to Docker Hub.

The changes made here are just small improvements that were suggested by a Dockerfile linter and/or GitHub Copilot, aside from the very end where the `CMD ./sneezy` line was removed. That change is to facilitate an upcoming PR that will fix the Docker volume so that immutable files updated via PRs (such as zonefile, news, and help file updates) aren't hidden by the old versions contained in the volume.

Identical changes will have to be made to the Dockerfile contained in the main sneezymud repo, as that's the file used by the Github Action to build the images it pushes to Docker Hub. I'll submit that as a separate PR over there.

Let me know if you see anything wrong or dumb in the changes here.