### PR TITLE
Revert changing ownership and running game from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     restart: always
 
   sneezy:
-    # Doing this here instead of in the Dockerfile ensures that the files inside the Docker volume have correct ownership. Those files aren't accessible to the Dockerfile, as they won't be mounted until the container is created. This is helpful in case a new file ever needs to be copied into the volume.
-    command: /bin/bash -c "chown -R sneezy:sneezy /home/sneezy && su sneezy -c './sneezy'"
     depends_on:
       - sneezy-db
     image: sneezymud/sneezymud:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,14 +30,11 @@ ARG UID=1000
 RUN useradd -m -u "$UID" sneezy && \
   mkdir -p /home/sneezy/code/objs/ && \
   mkdir -p /home/sneezy/lib
-
+WORKDIR /home/sneezy/code
 COPY --from=build /home/sneezy/sneezymud/code/sneezy /home/sneezy/code/sneezy
 COPY --from=build /home/sneezy/sneezymud/lib /home/sneezy/lib
 COPY --from=build /home/sneezy/sneezymud/code/sneezy.cfg /home/sneezy/code/sneezy.cfg
 RUN chown -R sneezy:sneezy /home/sneezy
 EXPOSE 7900
-
-# This is necessary because the lib folder is searched for relative to the working directory
-WORKDIR /home/sneezy/code
-
-# Don't run the binary here - do it from the docker-compose file to allow changing ownership of volume files before switching to sneezy user and starting game.
+USER sneezy
+RUN ./sneezy


### PR DESCRIPTION
This command is failing when run from the docker-compose.yml file on the prod and test servers, despite working on my dev computer's Docker setup.

Seems to have something to do with commands in the docker-compose file being run by the container's root user inside the container, whereas commands in the Dockerfile are run by the Docker's host OS as root.