### PR TITLE
Fix bloated Docker image size and launch command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,11 +30,13 @@ ARG UID=1000
 RUN useradd -m -u "$UID" sneezy && \
   mkdir -p /home/sneezy/code/objs/ && \
   mkdir -p /home/sneezy/lib
+
 WORKDIR /home/sneezy/code
-COPY --from=build /home/sneezy/sneezymud/code/sneezy /home/sneezy/code/sneezy
-COPY --from=build /home/sneezy/sneezymud/lib /home/sneezy/lib
-COPY --from=build /home/sneezy/sneezymud/code/sneezy.cfg /home/sneezy/code/sneezy.cfg
-RUN chown -R sneezy:sneezy /home/sneezy
+
+COPY --from=build --chown=sneezy:sneezy /home/sneezy/sneezymud/code/sneezy /home/sneezy/code/sneezy
+COPY --from=build --chown=sneezy:sneezy /home/sneezy/sneezymud/lib /home/sneezy/lib
+COPY --from=build --chown=sneezy:sneezy /home/sneezy/sneezymud/code/sneezy.cfg /home/sneezy/code/sneezy.cfg
+
 EXPOSE 7900
 USER sneezy
-RUN ./sneezy
+CMD ./sneezy


### PR DESCRIPTION
Fixes incorrect use of the RUN command instead of CMD.

Also uses the --chown flag in the COPY commands, which is the recommended way to set file permissions for copied files. Not having a separate RUN command that changes the ownership prevents the build process from creating a separate layer containing all the files for that command, which was greatly increasing the resulting image size after the recent reordering and combining of various layers.

Side note: The Dockerfile being edited here isn't actually used for anything currently, as the Docker images we use on the production server are created automatically via a GitHub Action, which uses the Dockerfile in the main sneezymud repo. So I'm mostly just keeping this file up to date for posterity.