### PR TITLE
Remove sneezy-lib volume from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - "7900:7900"
     restart: always
     volumes:
-      - sneezy-lib:/home/sneezy/lib/
       - sneezy-mutable:/home/sneezy/lib/mutable
 
   buildertools:
@@ -54,5 +53,4 @@ services:
 
 volumes:
   sneezydb:
-  sneezy-lib:
   sneezy-mutable:


### PR DESCRIPTION
This is part of https://github.com/sneezymud/sneezymud/issues/465, which changes the filepaths in the codebase so that mutable files are all contained within a new lib/mutable directory. Now that that change is confirmed working, we can safely remove the sneezy-lib volume from the docker-compose.yml file (and delete it on the Docker host).